### PR TITLE
Call GetUname() only once

### DIFF
--- a/src/Baseline/Platform.cs
+++ b/src/Baseline/Platform.cs
@@ -10,7 +10,7 @@ namespace Baseline
         {
             var name = GetUname();
             IsWindows = name == string.Empty;
-            IsDarwin = string.Equals(GetUname(), "Darwin", StringComparison.Ordinal);
+            IsDarwin = string.Equals(name, "Darwin", StringComparison.Ordinal);
             IsLinux = (!IsWindows && !IsDarwin);
         }
 


### PR DESCRIPTION
Came across this by accident. It's probably better to call it just once.