### PR TITLE
Update Baseline.csproj to correct licence Url

### DIFF
--- a/src/Baseline/Baseline.csproj
+++ b/src/Baseline/Baseline.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Baseline</AssemblyName>
     <PackageId>Baseline</PackageId>
     <PackageProjectUrl>https://github.com/JasperFX/Baseline</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/JasperFX/Baseline/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/JasperFX/Baseline/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/JasperFx/baseline/master/documentation/content/images/baseline.png</PackageIconUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
It had an extension which the github licence doesn't have causing a 404 when clicked through from Nuget Gallery