### PR TITLE
Fix globalization invariant mode. (#26)

### DIFF
--- a/src/BaselineTypeDiscovery/CallingAssembly.cs
+++ b/src/BaselineTypeDiscovery/CallingAssembly.cs
@@ -24,7 +24,7 @@ namespace BaselineTypeDiscovery
         private static string GetStackTraceInEnglish()
         {
             var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
             string trace = Environment.StackTrace;
             Thread.CurrentThread.CurrentUICulture = currentUiCulture;
             return trace;


### PR DESCRIPTION
Simply switched the hard-coded culture "en-US" to the invariant culture.

Proof that the stack trace is also written in english with the invariant culture: https://dotnetfiddle.net/HdfYUB

Fixes #26 